### PR TITLE
Avoid Reentrancy anomaly warning.

### DIFF
--- a/Sources/KingfisherManager+Rx.swift
+++ b/Sources/KingfisherManager+Rx.swift
@@ -13,8 +13,10 @@ extension Reactive where Base == KingfisherManager {
     public func retrieveImage(with source: Source,
                               options: KingfisherOptionsInfo? = nil) -> Single<Image> {
         return Single.create { [base] single in
-            let task = base.retrieveImage(with: source,
+            var task: DownloadTask?
+            task = base.retrieveImage(with: source,
                                           options: options) { result in
+                task = nil
                 switch result {
                 case .success(let value):
                     single(.success(value.image))


### PR DESCRIPTION
A SingleEvent should be called only once.
When the `task?.cancel()` was called during a Single is disposing of, this may cause another error result about task canceled, so the SingleEvent will be called twice.